### PR TITLE
Add a new note taking plugin to README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,6 +19,7 @@ Note that these plugins have not been peer-reviewed.
 - [Bierchermuesli/albert-dig](https://github.com/Bierchermuesli/albert-dig) ![GitHub Repo stars](https://img.shields.io/github/stars/Bierchermuesli/albert-dig) dig like DNS Lookup utility
 - [Bierchermuesli/albert-ripe](https://github.com/Bierchermuesli/albert-ripe) ![GitHub Repo stars](https://img.shields.io/github/stars/Bierchermuesli/albert-ripe) Whois lookups with Ripe
 - [Bierchermuesli/albert-deepl](https://github.com/Bierchermuesli/albert-deepl) ![GitHub Repo stars](https://img.shields.io/github/stars/Bierchermuesli/albert-deepl) deepl translation
+- [mohamed-sallam/quicknote-albert-plugin](https://github.com/mohamed-sallam/quicknote-albert-plugin) ![GitHub Repo stars](https://img.shields.io/github/stars/mohamed-sallam/quicknote-albert-plugin) Quick note taking with contexts and Obsidian compatibility
 
 
 ## Old/Unmaintained offcial plugins


### PR DESCRIPTION
# QuickNote Albert Plugin

A simple and efficient quick note-taking plugin for the Albert Launcher.

QuickNote allows you to seamlessly append notes to markdown files using "contexts". This makes it an incredibly powerful and fast companion to markdown-based knowledge bases like **Obsidian**. By setting your Obsidian vault folder as the notes directory, you can rapidly dump thoughts into specific daily notes or topics without ever opening the Obsidian app.

## Features
- **Fast Note-Taking**: Append bullet points to a markdown file instantly.
- **Context Switching**: Quickly switch the target markdown file (the "context") or create new ones on the fly.
- **Obsidian Integration**: Perfect for routing quick captures to your Obsidian vault.

## Configuration

1. Open Albert Settings -> Plugins -> QuickNote.
2. Under "Directory path for storing markdown notes", paste the path to your notes directory (e.g., `/home/user/Documents/Obsidian Vault/QuickNotes`). 
   *(Hit **Enter** in the text box to save it permanently!)*

## Usage

### 1. Set Context (`ctx`)
Use the `ctx` trigger to select which markdown file you want to write to.
- Type `ctx ideas` to set your context to `ideas.md`.
- If the file exists, it will select it. If not, it will create it for you.

### 2. Take a Note (`nt`)
Use the `nt` trigger to append a note to your current context.
- Type `nt Look into the new python features` and press Enter.
- It will automatically append `- Look into the new python features` to the bottom of your currently active context file.

